### PR TITLE
Fix strict error

### DIFF
--- a/src/Entity/Form/EntityBaseForm.php
+++ b/src/Entity/Form/EntityBaseForm.php
@@ -110,7 +110,8 @@ class EntityBaseForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     /** @var EntityTypeBaseInterface $entity_type */
-    $entity_type = reset($this->entity->type->referencedEntities());
+    $entities = $this->entity->type->referencedEntities();
+    $entity_type = reset($entities);
 
     // Save as a new revision if requested to do so.
     if (!$form_state->isValueEmpty('revision')) {


### PR DESCRIPTION
You cannot reset() things unless there is a variable.

```
Strict warning: Only variables should be passed by reference in Drupal\content_entity_base\Entity\Form\EntityBaseForm->save() (line 113 of modules/custom/content_entity_base/src/Entity/Form/EntityBaseForm.php).
Drupal\content_entity_base\Entity\Form\EntityBaseForm->save(Array, Object)
call_user_func_array(Array, Array)
```
