### PR TITLE
Update EntityTypeBaseForm::contentAddBodyField() to make body field optional

### DIFF
--- a/src/Entity/Form/EntityTypeBaseForm.php
+++ b/src/Entity/Form/EntityTypeBaseForm.php
@@ -140,6 +140,12 @@ class EntityTypeBaseForm extends EntityForm {
   protected function contentAddBodyField($entity_type_id, $label = 'Body') {
     // Get the content entity type.
     $content_entity_type = $this->getContentEntityTypeID();
+    
+    // Make the creation of a default body field optional. Do not create if
+    // there is no field storage configuration.
+    if (!FieldStorageConfig::loadByName($content_entity_type, 'body')) {
+      return;
+    }
 
     // Add or remove the body field, as needed.
     $field = FieldConfig::loadByName($content_entity_type, $entity_type_id, 'body');


### PR DESCRIPTION
Make the body field creation optional. I was unpleasantly surprised I couldn't just delete the field storage config for a body field. This fixes that by checking that the config exists.
