### PR TITLE
Optional entity label property

### DIFF
--- a/src/Entity/EntityBase.php
+++ b/src/Entity/EntityBase.php
@@ -265,4 +265,28 @@ class EntityBase extends ContentEntityBase implements EntityBaseInterface {
   public static function getCurrentUserId() {
     return array(\Drupal::currentUser()->id());
   }
+  
+  /**
+   * {@inheritdoc}
+   * 
+   * Allow for an optional label property by optionally inserting a dynamic label fabricated from bundle and ID.
+   */
+ public function label() {
+   $label = parent::label();
+
+   if (!$label) {
+     $class = $this->entityTypeManager()->getDefinition($this->getEntityType()->getBundleEntityType())->getClass();
+     if (is_callable([$class, 'load'])) {
+       $entity_type = $class::load($this->bundle());
+       if ($entity_type) {
+         $label = $entity_type->label() . ' ';
+       }
+     }
+
+     $label .= $this->id();
+   }
+
+   return $label;
+ }
+
 }


### PR DESCRIPTION
Right now, if someone wants to build an entity without a title/name/label property, Drupal doesn't like that. It throws errors that the label property doesn't exist or it leaves blank titles all over the place. This helps by providing a simple default title if none already exists.

On the content entity class, i.e. CebTestContent, you have to remove the label entity_keys entry, but then you don't have any proper label. This smooths the path by providing a fallback label if the label entity_key annotation doesn't exist.
