### PR TITLE
Adds a generic CallbackProxy to the test entity. 

### DIFF
--- a/content_entity_base.services.yml
+++ b/content_entity_base.services.yml
@@ -10,3 +10,7 @@ services:
     arguments: ['@entity.manager']
     tags:
       - { name: access_check, applies_to: _entity_access_revision }
+
+  content_entity_base.permission_handler:
+    class: \Drupal\content_entity_base\Entity\Access\EntityBasePermissions
+    arguments: ['@entity_type.manager']

--- a/src/Entity/Access/EntityBasePermissionsInterface.php
+++ b/src/Entity/Access/EntityBasePermissionsInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\content_entity_base\Entity\Access\EntityBasePermissionsInterface.
+ */
+
+namespace Drupal\content_entity_base\Entity\Access;
+
+use Drupal\content_entity_base\Entity\EntityTypeBaseInterface;
+use Drupal\Core\Entity\ContentEntityTypeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a class containing permission callbacks.
+ */
+interface EntityBasePermissionsInterface {
+
+  /**
+   * Gets an array of entity type permissions.
+   *
+   * @param ContentEntityTypeInterface $entity_type
+   *   The custom entity definition.
+   *
+   * @return array
+   *   The entity type permissions.
+   *
+   * @see \Drupal\user\PermissionHandlerInterface::getPermissions()
+   */
+  function entityPermissions(ContentEntityTypeInterface $entity_type = NULL);
+
+}

--- a/src/EntityBaseCallbackProxy.php
+++ b/src/EntityBaseCallbackProxy.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @file
+ *   Contains \Drupal\content_entity_base\EntityBaseCallbackProxy
+ */
+
+namespace Drupal\content_entity_base;
+
+
+use Drupal\content_entity_base\Entity\Access\EntityBasePermissionsInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+abstract class EntityBaseCallbackProxy implements EntityBaseCallbackProxyInterface, ContainerInjectionInterface {
+
+  public static $entity_type;
+
+  public static $bundle_type;
+
+  /**
+   * The content entity definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface|null
+   */
+  protected $entity_type_definition;
+
+  /**
+   * The bundle definition for the content entity.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface|null
+   */
+  protected $bundle_type_definition;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entity_type_manager;
+
+  /**
+   * The CEB permission handler.
+   *
+   * @var \Drupal\content_entity_base\Entity\Access\EntityBasePermissionsInterface
+   */
+  protected $permission_handler;
+
+  /**
+   * EntityBaseCallbackResolver constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *  The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityBasePermissionsInterface $permission_handler) {
+    $this->entity_type_manager = $entity_type_manager;
+    $this->permission_handler = $permission_handler;
+
+    $this->entity_type_definition = $this->entity_type_manager->getDefinition(static::$entity_type);
+    $this->bundle_type_definition = $this->entity_type_manager->getDefinition(static::$bundle_type);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('content_entity_base.permission_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityPermissions() {
+    return $this->permission_handler->entityPermissions($this->entity_type_definition);
+  }
+}

--- a/src/EntityBaseCallbackProxyInterface.php
+++ b/src/EntityBaseCallbackProxyInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ *   Contains \Drupal\content_entity_base\EntityBaseCallbackProxyInterface.
+ */
+
+namespace Drupal\content_entity_base;
+
+interface EntityBaseCallbackProxyInterface {
+
+  /**
+   * Proxies the entity permissions callback.
+   *
+   * @return array
+   *   The entity type permissions.
+   */
+  public function entityPermissions();
+}

--- a/tests/modules/ceb_test/ceb_test.permissions.yml
+++ b/tests/modules/ceb_test/ceb_test.permissions.yml
@@ -1,2 +1,2 @@
 permission_callbacks:
-  - \Drupal\ceb_test\Entity\Access\CebTestContentPermissions::entityPermissions
+  - \Drupal\ceb_test\CallbackProxy::entityPermissions

--- a/tests/modules/ceb_test/src/CallbackProxy.php
+++ b/tests/modules/ceb_test/src/CallbackProxy.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @file
+ *   Contains \Drupal\ceb_test\CallbackProxy
+ */
+
+namespace Drupal\ceb_test;
+
+
+use Drupal\content_entity_base\EntityBaseCallbackProxy;
+
+/**
+ * Provides a callback proxy based off the content_entity_base callback proxy.
+ * The only thing that should be required in this file is the $entity_type and
+ * $bundle_type variables. Functions in the base class will handle instantiating
+ * objects required by the callback based on these two settings.
+ *
+ * @package Drupal\ceb_test
+ */
+class CallbackProxy extends EntityBaseCallbackProxy{
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $entity_type = 'ceb_test_content';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $bundle_type = 'ceb_test_content_type';
+
+}


### PR DESCRIPTION
The purpose of the CallbackProxy is to pass entity information to some content_entity_base class. 
The one implemented use of the callback proxy is to get rid of the permissions callback class for the custom entity. Instead, in your permissions file you would use `\Drupal\foo\CallbackProxy::entityPermissions`. In your `foo.permissions.yml` file for a callback.
