### PR TITLE
[Bugfix] The entity module requires the `bundle_type` var for `entity…

### DIFF
--- a/content_entity_base.module
+++ b/content_entity_base.module
@@ -33,6 +33,7 @@ function content_entity_base_theme_registry_alter(&$theme_registry) {
     $theme_registry['entity_add_list'] = [
       'variables' => [
         'bundles' => [],
+        'bundle_type' => NULL,
         'add_bundle_message' => NULL,
       ],
       'template' => 'ceb-entity-add-list',

--- a/src/Entity/Controller/EntityBaseController.php
+++ b/src/Entity/Controller/EntityBaseController.php
@@ -114,6 +114,7 @@ class EntityBaseController extends EntityController {
     $bundle_entity_type_id = $entity_type->getBundleEntityType();
     $build = [
       '#theme' => 'entity_add_list',
+      '#bundle_type' => $bundle_entity_type_id,
       '#bundles' => [],
     ];
     if ($bundle_entity_type_id) {
@@ -156,7 +157,7 @@ class EntityBaseController extends EntityController {
       $build['#bundles'][$bundle_name] = [
         'label' => $bundle_info['label'],
         'description' => isset($bundle_info['description']) ? $bundle_info['description'] : '',
-        'add_link' => Link::createFromRoute($bundle_info['label'], $form_route_name, [$bundle_key => $bundle_name]),
+        'add_link' => Link::createFromRoute($bundle_info['label'], $form_route_name, [$bundle_argument => $bundle_name]),
       ];
     }
 


### PR DESCRIPTION
…_add_list`.

Using the bundle key for the entity type key for the link url causes a failure.
