### PR TITLE
Fix warning

### DIFF
--- a/content_entity_base.module
+++ b/content_entity_base.module
@@ -54,6 +54,11 @@ function content_entity_base_theme_registry_alter(&$theme_registry) {
  *     available if the entity type uses bundle entities.
  */
 function content_entity_base_preprocess_entity_add_list(&$variables) {
+  // Don't run this code in 8.1 or later, because
+  // \template_preprocess_entity_add_list does the same already.
+  if (version_compare(\Drupal::VERSION, '8.1') === 1) {
+    return;
+  }
   foreach ($variables['bundles'] as $bundle_name => $bundle_info) {
     $variables['bundles'][$bundle_name]['description'] = [
       '#markup' => $bundle_info['description'],


### PR DESCRIPTION
Currently we execute the same preprocess function twice. That results into error messages like:

```
Warning: strlen() expects parameter 1 to be string, array given in Drupal\Component\Utility\Unicode::validateUtf8() (line 686 of core/lib/Drupal/Component/Utility/Unicode.php).
Drupal\Component\Utility\Unicode::validateUtf8(Array) (Line: 63)
Drupal\Component\Utility\Xss::filter(Array, Array) (Line: 722)
Drupal\Core\Render\Renderer->ensureMarkupIsSafe(Array) (Line: 368)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 195)
Drupal\Core\Render\Renderer->render(Array) (Line: 462)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 57)
__TwigTemplate_1b857ac057350d9d5f14bfab9f960d199ebdfd8cbbcb3e2c5cf577d9be57dc36->doDisplay(Array, Array) (Line: 381)
Twig_Template->displayWithErrorHandling(Array, Array) (Line: 355)
Twig_Temp
```

Let's ensure this doesn't happen anymore
