### PR TITLE
Remove outdated 8.0.x and add 8.2.x core versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
   - hhvm
 
 env:
-  - DRUPAL_VERSION=8.0.x ENTITY_VERSION=8.x-0.x
   - DRUPAL_VERSION=8.1.x ENTITY_VERSION=8.x-1.x
+  - DRUPAL_VERSION=8.2.x ENTITY_VERSION=8.x-1.x
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This removes useless failures

> $ drush dl -y --drupal-project-rename=drupal drupal-$DRUPAL_VERSION
> Could not locate drupal version 8.0.x-dev.                           [error]
> Could not download requested project(s).                             [error]
